### PR TITLE
Add ls-command

### DIFF
--- a/04.ls/ls_command.rb
+++ b/04.ls/ls_command.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+DISPLAY_MAX_COLUMNS = 3
+
+def list_files
+  Dir.glob('*')
+end
+
+def round_to_specified_size(length, round_num)
+  ((length + round_num) / round_num) * round_num
+end
+
+def build_columns(lists, columns)
+  display_rows = (lists.length.to_f / columns).ceil
+  lists.fill(nil, lists.length, display_rows * columns - lists.length)
+  lists.each_slice(display_rows).to_a.transpose
+end
+
+def display_list_files
+  files = list_files
+  max_length = files.map(&:length).max
+  build_columns(list_files, DISPLAY_MAX_COLUMNS).each do |row|
+    puts row.map { |f| f.to_s.ljust(round_to_specified_size(max_length, 8)) }.join
+  end
+end
+
+display_list_files

--- a/04.ls/ls_command.rb
+++ b/04.ls/ls_command.rb
@@ -12,15 +12,17 @@ end
 
 def build_columns(lists, columns)
   display_rows = (lists.length.to_f / columns).ceil
-  lists.fill(nil, lists.length, display_rows * columns - lists.length)
+  lists.fill('', lists.length, display_rows * columns - lists.length)
   lists.each_slice(display_rows).to_a.transpose
 end
 
 def display_list_files
   files = list_files
+  return if files.empty?
+
   max_length = files.map(&:length).max
-  build_columns(list_files, DISPLAY_MAX_COLUMNS).each do |row|
-    puts row.map { |f| f.to_s.ljust(round_to_specified_size(max_length, 8)) }.join
+  build_columns(files, DISPLAY_MAX_COLUMNS).each do |row|
+    puts row.map { |f| f.ljust(round_to_specified_size(max_length, 8)) }.join
   end
 end
 


### PR DESCRIPTION
lsコマンドを作成

macOS：Ventura 13.7.6
ターミナル上のlsコマンドの列幅：8の倍数を保つパターン